### PR TITLE
Update for read mapping

### DIFF
--- a/statistics/README.txt
+++ b/statistics/README.txt
@@ -1,16 +1,41 @@
-As I will remove Picard and simplify the input for the program, the previous README was out of date.
-Please disregard previous instructions, and ignore Picard's presence in this project, it will soon be removed.
-
 Current statistics included in this program:
 
-Assembly length
-Number of contigs
-Number of "clean" windows of a given size (default 100bp).  A "clean" window is defined as one with <50% 'N' base pairs.
-Number of "large" contigs.  A "large" contig is one above a given size (default 1000bp).
-List of contig sizes
-GC% composition
-GC% composition of windows of a given size (default 100bp).
-NX values (1-100)
-Expected number of 'N' pairs per a given number of nucleotides (default 10000bp).
+- Assembly length
+- Number of contigs
+- Number of "clean" windows of a given size (default 100bp).  A "clean" window is defined as one with <50% 'N' base - pairs.
+- Number of "large" contigs.  A "large" contig is one above a given size (default 1000bp).
+- List of contig sizes
+- GC% composition
+- GC% composition of windows of a given size (default 100bp).
+- NX values (1-100)
+- Expected number of 'N' pairs per a given number of nucleotides (default 10000bp).
 
-I will examine the professor's document and add any other statistics that can be calculated within the same sweep as these.
+If the untested BWT read-mapping works, I also have implemented these:
+
+- % coverage of contigs by reads
+- Number of gaps between mapped reads
+- Number of unaligned reads (partial and full)
+- % duplicate coverage of contigs by reads
+- Longest mapping of a single read
+
+The program right now assumes that there exists a FASTA and FASTQ file both with the same name (aside from filetype) available to it.  The FASTA file is assumed to hold contigs, not scaffolds or chromosomes.  It takes the following arguments by command line (ones with * are mandatory):
+
+I=input_file_name (*)
+Determines what the name of the input file is (in FASTA format, such as filename.fasta).
+
+W=window_size
+Determines what the size of "windows" examined should be.  Default is 100bp.
+
+L=large_size
+Determines at what size a contig will be considered "large."  Default is 1000bp.
+
+N=n_size
+Determines the relative size where the expected number of N pairs will be.  Default is 10000bp.
+(NOTE:  Because the program is working with contigs, not scaffolds, this may be pointless.
+I may either alter the program to also calculate via scaffolds, or simply remove this statistic)
+
+O=out_file
+Determines what the output file name should be.  Default is stat_out.
+
+E=allowed_error
+Determines at what edit distance a substring of a contig will match to a read.  Default is 5.

--- a/statistics/statprog.java
+++ b/statistics/statprog.java
@@ -203,7 +203,7 @@ public class statprog {
 				if (j != 0)
 					for (int k = 0; k < 6; ++k) {
 						O[k][j] = O[k][j - 1];
-						OP[k][j] = O[k][j - 1];
+						OP[k][j] = OP[k][j - 1];
 					}
 				O[charCode(BWT.charAt(j))][j]++;
 				OP[charCode(rBWT.charAt(j))][j]++;

--- a/statistics/statprog.java
+++ b/statistics/statprog.java
@@ -1,5 +1,5 @@
 /*
-statprog.java v1.3
+statprog.java v2.0
 senior design group 8
 
 VERSION NOTES:
@@ -27,8 +27,9 @@ add some basic output, right now just a text file
 1.2
 correcting error in picard tool syntax
 
-1.3
-correcting picard use so thread does not deadlock
+2.0
+removed picard
+created basic read mapping code (untested) - a whole lot of it
 
 
 program description:
@@ -55,89 +56,297 @@ public class statprog {
 	variable explanations
 		cg					-		CG% counter.  counts the total number of GC pairs in the assembly
 		len					-		Length of assembly
-		wind100				-	Windows where they are fewer than 50% N
-		contigs				-	Number of contigs in assembly.
-		bigContigs			-	Number of contigs of large size
-		Nnum				-	Number of Ns found
-		contigArr			-	Array of contig sizes
-		gcWind				-	CG% counter for windows (not the OS)
-		NX					-	Array of NX values
-		calculateReference	- 
-		endOfFile			-	Indicates end of input has been reached
-		WindowSize			-	Constant defining size of windows
-		LargeSize			-	Constant defining minimum size of large contigs
-		NSize				-	Constant defining for what size the expected number of Ns will be
-		DebugMode			-	Constant determining if program will run in debug mode
+		wind100				-		Windows where they are fewer than 50% N
+		contigs				-		Number of contigs in assembly.
+		bigContigs			-		Number of contigs of large size
+		Nnum				-		Number of Ns found
+		contigArr			-		Array of contig sizes
+		gcWind				-		CG% counter for windows (not the OS)
+		NX					-		Array of NX values
+		endOfFile			-		Indicates end of input has been reached
+		WindowSize			-		Constant defining size of windows
+		LargeSize			-		Constant defining minimum size of large contigs
+		NSize				-		Constant defining for what size the expected number of Ns will be
+		DebugMode			-		Constant determining if program will run in debug mode
+		AllowedError		-		Maximum number of mismatchings allowed per each read mapping
 	 */
 	public static BigInteger len, cg, wind100, contigs, bigContigs, largestContig, Nnum;
 	public static ArrayList<BigInteger> contigArr, gcWind;
 	public static BigInteger[] NX;
-	public static boolean calculateReference;
+	public static ArrayList<StringBuilder> genome;
 	public static boolean endOfFile;
 	
 	public static long WindowSize = 100;
 	public static long LargeSize = 1000;
 	public static long NSize = 100000;
 	
+	public static int AllowedError = 5;
+	
 	public static final boolean DebugMode = false;
+	
+	public static Random r;
 	
 	
 	public static void main(String[] args) throws IOException, InterruptedException {
 		
 		init();
 		String input_file = "";
-		String ref_file = "";
-		String out_files = "stat_out";
-		for (int i = 0; i < args.length && !DebugMode; ++i)
+		String out_files = "stat_out"; // default
+		
+		// processing command-line arguments
+		// allows for customization of statistics (mostly for testing purposes)
+		for (int i = 0; i < args.length; ++i)
 			switch(args[i].charAt(0)) {
 			case 'I': input_file = args[i].substring(2); break;
-			case 'R':
-				calculateReference = true;
-				ref_file = args[i].substring(2);
-				break;
 			case 'W': WindowSize = Long.parseLong(args[i].substring(2)); break;
 			case 'L': LargeSize = Long.parseLong(args[i].substring(2)); break;
 			case 'N': NSize = Long.parseLong(args[i].substring(2)); break;
 			case 'O': out_files = args[i].substring(2); break;
+			case 'E': AllowedError = Integer.parseInt(args[i].substring(2)); break;
 			}
-		if (DebugMode) {
-			out_files = "sample";
-			calculateReference = true;
-			ref_file = "sample.fasta";
-			input_file = "sample.fastq";
-		}
 		
 		
-		FastScanner in;
-//		if (DebugMode)
-//			in = new FastScanner(System.in);
-//		else
-			in = new FastScanner(new File(input_file));
-		read(in);
+		FirstScanner in = new FirstScanner(new File(input_file));
 		
+		// grab stats from a single sweep of the assembly
+		read1(in);
 		calculateNX();
 		
-
+		/*
+		alright this next section is the read-mapping section
+		and it's a doozy, i'll tell you that - i'll put some heavy comments in
+		because i don't expect this to work on the first go and it may not work exactly as we want to in the end
 		
+		basic runthrough: i'm not doing the trees or any of that for the read-mapping, i'll leave that to someone else
+		instead i saw the paper on the burrows-wheeler transform (BWT) in conjunction with suffix arrays (SA) and decided to use that
+		since i have worked with SAs before
 		
-		if (calculateReference) {
-			ProcessBuilder pb = new ProcessBuilder("java", "-Xmx2g", "-jar", "picard.jar", "FastqToSam", "F1="+(input_file.replace(".fasta", ".fastq")), "O="+(input_file.replace(".fasta", ".bam")), "SM=filler");
-			pb.redirectErrorStream(true);
-			Process p = pb.start();
-			BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
-			String line;
-			while ((line = reader.readLine()) != null)
-			    System.out.println("tasklist: " + line);
-			p.waitFor();
-			pb = new ProcessBuilder("java", "-Xmx2g", "-jar", "picard.jar", "CollectMultipleMetrics", "I="+(input_file.replace(".fasta", ".bam")), "O="+out_files, "R="+ref_file);
-			pb.redirectErrorStream(true);
-			p = pb.start();
-			reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
-			while ((line = reader.readLine()) != null)
-			    System.out.println("tasklist: " + line);
-			p.waitFor();
+		the read mapping is that we generate the suffix array for the genome (in reality multiple suffix arrays for each contig)
+		and then we'll create the BWT string from this, and then precalc a bunch of information
+		using that information, we can quickly match all locations where the string matches in the genome with a given error (think edit distance
+		if you remember dynamic programming).
+		
+		we select matchings for the reads (for now randomly because it is even more complex work to determine best matchings) and then
+		we run through and calculate alignment statistics
+		
+		this is definitely the bottleneck on runtime for this program
+		calculating a suffix array takes O(n*(logn)^2) time, which is supposedly good enough for genome work - however i'm doing it on a lot of
+		contigs, not a single genome.  there's a lot of linear sweeps on the genome through here, but it's always a constant order of times.
+		in addition, i'm storing all these suffix arrays for each contig
+		in further addition, while i'm only temporarily storing the precalc arrays, i am running a recursive algorithm to find the matching
+		intervals - this may have some concerns with stack and heap space in memory.  i could possibly improve this but it would be kinda difficult
+		with how complicated this part already is
+		so there's both a little runtime and memory concerns, which isn't a good scenario.  i don't know how much memory this program will be
+		allocated when run, it might need to be given more than usual.
+		
+		there are definitely parallelizable elements to this (after all, each read can be mapped separately from one another based on how i'm doing it)
+		but once again, this is already pretty complicated without also trying to parallelize it.  for now i'll keep it serial unless it does fail
+		to run in a reasonable time.
+		
+		testing this is going to be quite a bundle of fun
+		if i can't prove the mapping works properly in time for us to be finished, i'll just remove the mapping and work with the basics
+		 */
+		
+		// assume there exists the read file with the same name as the assembly (aside from file type)
+		ArrayList<String> reads = new ArrayList<String>();
+		FastScanner newIn = new FastScanner(new File(input_file.replace(".fasta", ".fastq")));
+		
+		// collect all the reads (account for FASTQ format)
+		read2(newIn, reads);
+		
+		// Create an array of arrays of triplets, storing, for each read, the SA interval and contig it was found in
+		ArrayList<Trip>[] locs = new ArrayList[reads.size()];
+		for (int i = 0; i < reads.size(); ++i)
+			locs[i] = new ArrayList<Trip>();
+		
+		// store the SAs for each contig once found, they will be needed again later
+		ArrayList<Suf[]> suffixArrays = new ArrayList<Suf[]>();
+		
+		// iterate through each contig
+		for (int i = 0; i < genome.size(); ++i) {
+			
+			// generate a suffix array on the contig, and also on the reversed contig (yes, we need that)
+			Suf[] suffixArray = buildSuffixArray(genome.get(i));
+			Suf[] rSuffixArray = buildSuffixArray(reverse(genome.get(i)));
+			
+			// create the BWT string for the SA, and the BWT string for the SA of the reversed contig
+			StringBuilder BWT = new StringBuilder("");
+			StringBuilder rBWT = new StringBuilder("");
+			
+			// go through and build the strings based on the SAs
+			for (int j = 0; j < genome.get(i).length(); ++j) {
+				BWT = BWT.append((suffixArray[j].ind + genome.get(i).length() - 1) % genome.get(i).length());
+				rBWT = rBWT.append((rSuffixArray[j].ind + genome.get(i).length() - 1) % genome.get(i).length());
+			}
+			
+			// precalc the C, O, and O' arrays for this contig
+			// C[c]			-		Array containing the number of letters smaller than the given letter c in the contig
+			// O[c][i]		-		Array containing the number of matches to the letter c in the prefix of length i in the BWT string
+			// O'			-		Same as O, but on the rBWT string.  Called OP in code.
+			
+			// calculate C
+			int[] C = new int[6]; // i am assuming only 6 relevant characters:  C, G, N, A, T, $
+			for (int j = 0; j < genome.get(i).length(); ++j)
+				for (int k = charCode(genome.get(i).charAt(j)) + 1; k < 6; ++k)
+					++C[k];
+			
+			// calculate O and O'
+			int[][] O = new int[6][genome.get(i).length()];
+			int[][] OP = new int[6][genome.get(i).length()];
+			
+			for (int j = 0; j < BWT.length(); ++j) {
+				if (j != 0)
+					for (int k = 0; k < 6; ++k) {
+						O[k][j] = O[k][j - 1];
+						OP[k][j] = O[k][j - 1];
+					}
+				O[charCode(BWT.charAt(j))][j]++;
+				OP[charCode(rBWT.charAt(j))][j]++;
+			}
+			
+			// iterate through each read and see if the range at which it matches in this contig (if it matches at all)
+			for (int j = 0; j < reads.size(); ++j) {
+				Trip p = presearch(reads.get(j), C, O, OP, AllowedError);
+				if (p != null && p.a <= p.b) {
+					p.c = i;
+					locs[j].add(p);
+				}
+			}
+			
+			// store the SA we found, we will need it later
+			suffixArrays.add(suffixArray);
 		}
 		
+		// The read mappings are a triplet:  the contig number, the location in the contig, and the length of the read
+		// null indicates that a read was not mapped (this can happen)
+		Map[] map = new Map[reads.size()];
+		Arrays.fill(map, null);
+		
+		// find a mapping for each read from among its potential mappings
+		for (int i = 0; i < locs.length; ++i) {
+			
+			// first find out the number of possible locations the read could be mapped to
+			int sum = 0;
+			for (int j = 0; j < locs[i].size(); ++j)
+				if (locs[i].get(j) != null) {
+					Trip temp = locs[i].get(j);
+					sum += temp.b - temp.a + 1;
+				}
+			
+			// randomly pick one of these locations and map the read to it
+			int ind = r.nextInt(sum);
+			for (int j = 0; j < locs[i].size(); ++j)
+				if (locs[i].get(j) != null) {
+					Trip temp = locs[i].get(j);
+					if (ind < temp.b - temp.a + 1) {
+						map[i] = new Map(temp.c, temp.a + ind, reads.get(i).length());
+						break;
+					}
+					ind -= temp.b - temp.a + 1;
+				}
+		}
+		
+		// we're going to treat the alignment statistics evaluation as a sweep on intervals
+		// since this requires all "events" to be sorted, we'll use a priority queue to pull out events in order
+		PriorityQueue<Event> q = new PriorityQueue<Event>();
+		
+		// first add each contig start and end
+		for (int i = 0; i < genome.size(); ++i) {
+			q.add(new Event(i, 0, 0));
+			q.add(new Event(i, genome.get(i).length(), 3));
+		}
+		
+		// next add each mapping start and end
+		for (int i = 0; i < map.length; ++i) if (map[i] != null) {
+			q.add(new Event(map[i].cont, suffixArrays.get(map[i].cont)[map[i].loc].ind, 1));
+			q.add(new Event(map[i].cont, suffixArrays.get(map[i].cont)[map[i].loc].ind + map[i].len, 2));
+		}
+		
+		// now here comes the fun part, we need to pull out the events and keep track of a lot of info to calculate the stats
+		long align = 0, dupalign = 0, numGaps = 0, longestAlign = 0, fullUnalign = 0, partUnalign = 0;
+		int prev = 0, prev2 = 0, curContig = -1, stack = 0, prevEnd = 0;
+		boolean inContig = false;
+		
+		// first count the number of reads that are not aligned at all, as well as the longest part of the assembly that is aligned
+		for (int i = 0; i < map.length; ++i) {
+			if (map[i] == null)
+				++fullUnalign;
+			else
+				longestAlign = Math.max(longestAlign, Math.min(genome.get(map[i].cont).length(),
+						suffixArrays.get(map[i].cont)[map[i].loc].ind + map[i].len) - suffixArrays.get(map[i].cont)[map[i].loc].ind);
+		}
+		
+		// now go through all "events" (start/ends of reads and contigs)
+		while (!q.isEmpty()) {
+			Event e = q.poll();
+			
+			// we have moved on to a new contig, update everything - some of this is redundant but just for peace of mind and safety
+			if (e.cont != curContig) {
+				prev = 0;
+				prev2 = 0;
+				stack = 0;
+				prevEnd = 0;
+				curContig = e.cont;
+				inContig = false;
+			}
+			
+			// check the event type we are on
+			switch (e.type) {
+			case 0: // this is the beginning of a contig
+				partUnalign += stack; // this should never do anything based on how the read mapping works, but i included it regardless
+				inContig = true; // we are now in a contig
+				break;
+				
+			case 1: // this is the beginning of a read
+				// this is the first read for this part of the contig, so update the values before incrementing the stack
+				if (stack == 0) {
+					prev = e.loc;
+					if (prevEnd != e.loc)
+						++numGaps;
+				}
+				
+				// this is the second read of this part of the contig, so update the first encountered location of duplicate coverage
+				if (stack == 1)
+					prev2 = e.loc;
+				
+				// push the "stack" - this is like a parsing problem, but it's primitive enough that we don't need a real stack, just a counter
+				++stack;
+				break;
+				
+			case 2: // this is end of a read
+				// we are ending coverage, so update some stuff
+				if (stack == 1) {
+					if (inContig)
+						align += e.loc - prev;
+					else
+						align = genome.get(curContig).length() - prev;
+					prevEnd = e.loc;
+				}
+				
+				// we are ending duplicate coverage, so update
+				else if (stack == 2) {
+					if (inContig)
+						dupalign += e.loc - prev2;
+					else
+						dupalign = genome.get(curContig).length() - prev2;
+				}
+				
+				// if we ended outside of a contig, then this read is partially unaligned
+				// (this is technically false due to the edit distance allowed error, but that is small enough error to ignore, hopefully)
+				if (!inContig)
+					++partUnalign;
+				
+				// pop off the "stack"
+				--stack;
+				break;
+				
+			case 3: // this is the end of a contig
+				inContig = false;
+				break;
+			}
+		}
+		
+				
 		if (DebugMode)
 			sysprint();
 		else {
@@ -157,6 +366,12 @@ public class statprog {
 			for (int i = 1; i < NX.length; ++i)
 				out.printf("%s ", NX[i].toString());
 			out.printf("\nNumber of N per %dbp:  %.9f\n", NSize, ((double) Nnum.longValue()) / ((double) len.longValue()) * NSize);
+			out.printf("Aligned genome:  %.9f\n", ((double) align) / (Double.parseDouble(len.toString())));
+			out.printf("Duplication rate:  %.9f\n", ((double) dupalign) / (Double.parseDouble(len.toString())));
+			out.printf("Number of gaps: %d\n", numGaps);
+			out.printf("Largest alignment length:  %d\n", longestAlign);
+			out.printf("Number of fully unaligned reads:  %d\n", fullUnalign);
+			out.printf("Number of partially unaligned reads:  %d\n", partUnalign);
 			out.close();
 		}
 		
@@ -176,12 +391,15 @@ public class statprog {
 		WindowSize = 100;
 		LargeSize = 1000;
 		NSize = 100000;
+		genome = new ArrayList<StringBuilder>();
+		r = new Random();
 	}
 	
 	// splitting the reading into its own function
 	// for better readability, more of this should be put into separate functions
 	// it's kinda spaghetti-i right now and debugging this will be difficult when i finally get to testing
-	public static void read(FastScanner in) {
+	// this SHOULD account for FASTA file format
+	public static void read1(FirstScanner in) {
 		
 		String str = "";
 		int idx = 0;
@@ -194,6 +412,8 @@ public class statprog {
 		// ind marks how far in the window of 100 we have gone
 		long ind = 0;
 		
+		genome.add(new StringBuilder(""));
+		
 		// prev will mark the number of cumulative GCs found in previous windows of 100
 		BigInteger prev = BigInteger.ZERO;
 		
@@ -203,12 +423,13 @@ public class statprog {
 		do {
 			if (idx == str.length()) {
 				idx = 0;
-				str = in.next();
+				while (in.badLine)
+					str = in.next();
 //				if (DebugMode && str.charAt(0) == '$')
 //					endOfFile = true;
 			}
 			
-			if (!endOfFile && str.charAt(0) != '>') {
+			if (!endOfFile && str.charAt(0) != '>' && str.charAt(0) != ';') {
 			
 				inContig = true;
 				
@@ -234,17 +455,40 @@ public class statprog {
 					ind = 0;
 					N = 0;
 				}
+				
+				genome.get(genome.size() - 1).append(str.charAt(idx));
 			}
 			
 			// this executes when we are finished with the current contig
 			else if (inContig) {
+				genome.get(genome.size() - 1).append("$");
+				genome.add(new StringBuilder(""));
 				inContig = false;
 				updateContigs(size);
 				
 				size = BigInteger.ZERO;
 			}
+			
+			// this executes if we encounter a line we shouldn't be reading (starts with ; or >)
+			else {
+				in.badLine = true;
+			}
 			++idx;
 		} while (!endOfFile);
+	}
+	
+	// get the reads - hopefully this accounts for FASTQ format correctly
+	public static void read2(FastScanner in, ArrayList<String> a) {
+		endOfFile = false;
+		while (!endOfFile) {
+			String temp = in.next();
+			if (in.x == 2)
+				a.add(temp);
+			else {
+				int t = in.x;
+				while (t == in.x) in.next();
+			}
+		}
 	}
 	
 	public static void updateWindows(long N, BigInteger prev) {
@@ -281,6 +525,38 @@ public class statprog {
 		}
 	}
 	
+	public static Suf[] buildSuffixArray(StringBuilder str) {
+		Suf[] a = new Suf[str.length()];
+		for (int i = 0; i < a.length; ++i)
+			a[i] = new Suf(i, str.charAt(i) - '$', (i + 1 < a.length) ? (str.charAt(i + 1) - '$') : -1);
+		Arrays.sort(a);
+		int[] ind = new int[a.length];
+		Arrays.fill(ind, 0);
+		for (int k = 4; k < 2 * a.length; k = k * 2) {
+			int rank = 0;
+			int prevRank = a[0].rank[0];
+			a[0].rank[0] = rank;
+			ind[a[0].ind] = 0;
+			for (int i = 1; i < a.length; ++i) {
+				if (a[i].rank[0] == prevRank && a[i].rank[1] == a[i - 1].rank[1]) {
+					prevRank = a[i].rank[0];
+					a[i].rank[0] = rank;
+				}
+				else {
+					prevRank = a[i].rank[0];
+					a[i].rank[0] = ++rank;
+				}
+				ind[a[i].ind] = i;
+			}
+			for (int i = 0; i < a.length; ++i) {
+				int nextInd = a[i].ind + k / 2;
+				a[i].rank[1] = (nextInd < a.length) ? a[ind[nextInd]].rank[0] : -1;
+			}
+			Arrays.sort(a);
+		}
+		return a;
+	}
+	
 	// this might look ugly, but it's for debug purposes only
 	public static void sysprint() {
 		System.out.printf("Assembly Length: %s\n", len.toString());
@@ -300,12 +576,98 @@ public class statprog {
 		System.out.printf("\nNumber of N per %dbp:  %.9f\n", NSize, ((double) Nnum.longValue()) / ((double) len.longValue()) * NSize);
 	}
 	
+	public static int charCode(char c) {
+		switch (c) {
+		case '$': return 0;
+		case 'A': return 1;
+		case 'C': return 2;
+		case 'G': return 3;
+		case 'N': return 4;
+		default: return 5;
+		}
+	}
+	
+	public static class Map {
+		int cont, loc, len;
+		Map(int a, int b, int c) {
+			cont = a;
+			loc = b;
+			len = c;
+		}
+	}
+	
+	public static class Trip {
+		int a, b, c;
+		Trip(int x, int y, int z) {
+			a = x;
+			b = y;
+			c = z;
+		}
+		Trip union(Trip t) {
+			Trip ret = new Trip(0, 0, -1);
+			if (t == null)
+				return new Trip(a, b, -1);
+			ret.a = Math.min(a, t.a);
+			ret.b = Math.max(b, t.b);
+			return ret;
+		}
+	}
+	
+	public static Trip presearch(String s, int[] C, int[][] O, int[][] OP, int e) {
+		int[] D = calcD(s, C, OP);
+		return search(D, C, O, s, s.length() - 1, e, 1, C.length - 1);
+	}
+	
+	public static int[] calcD(String s, int[] C, int[][] O) {
+		int z = 0, k = 1, l = C.length - 1;
+		int[] ret = new int[s.length()];
+		for (int i = 0; i < s.length(); ++i) {
+			k = C[charCode(s.charAt(i))] + O[charCode(s.charAt(i))][k - 1] + 1;
+			l = C[charCode(s.charAt(i))] + O[charCode(s.charAt(i))][l];
+			if (k > l) {
+				k = 1;
+				l = C.length - 1;
+				z++;
+			}
+			ret[i] = z;
+		}
+		return ret;
+	}
+	
+	public static Trip search(int[] D, int[] C, int[][] O, String s, int i, int z, int k, int l) {
+		if (z < D[i])
+			return null;
+		if (i < 0)
+			return new Trip(k, l, -1);
+		Trip temp = search(D, C, O, s, i - 1, z - 1, k, l);
+		for (char c : new char[]{'A', 'C', 'G', 'T'}) {
+			k = C[charCode(c)] + O[charCode(c)][k - 1] + 1;
+			l = C[charCode(c)] + O[charCode(c)][l];
+			if (k <= l) {
+				temp = temp.union(search(D, C, O, s, i, z - 1, k, l));
+				if (c == s.charAt(i))
+					temp = temp.union(search(D, C, O, s, i - 1, z, k, l));
+				else
+					temp = temp.union(search(D, C, O, s, i - 1, z - 1, k, l));
+			}
+		}
+		return temp;
+	}
+	
+	public static StringBuilder reverse(StringBuilder s) {
+		StringBuilder ret = new StringBuilder("");
+		for (int i = s.length() - 1; i >= 0; --i)
+			ret = ret.append(s.charAt(i));
+		return ret;
+	}
+	
 	// this is an improvement to the java Scanner class
 	// Scanner is quite slow on large inputs, and genomes can get large
 	// FastScanner has similar functionality but uses BufferedReader, which is faster
 	public static class FastScanner {
 		BufferedReader br;
 		StringTokenizer st;
+		int x;
 		FastScanner(File f) throws FileNotFoundException {
 			br = new BufferedReader(new FileReader(f));
 			st = new StringTokenizer("");
@@ -318,12 +680,75 @@ public class statprog {
 			while (!st.hasMoreTokens()) {
 				try {
 					st = new StringTokenizer(br.readLine());
+					x = (x + 1) % 4;
 				} catch (Exception e) {
 					endOfFile = true;
 					return "";
 				}
 			}
 			return st.nextToken();
+		}
+	}
+	
+	public static class FirstScanner {
+		BufferedReader br;
+		StringTokenizer st;
+		boolean badLine;
+		FirstScanner(File f) throws FileNotFoundException {
+			br = new BufferedReader(new FileReader(f));
+			st = new StringTokenizer("");
+		}
+		FirstScanner(InputStream in) {
+			br = new BufferedReader(new InputStreamReader(in));
+			st = new StringTokenizer("");
+		}
+		String next() {
+			while (!st.hasMoreTokens()) {
+				try {
+					st = new StringTokenizer(br.readLine());
+					badLine = false;
+				} catch (Exception e) {
+					endOfFile = true;
+					return "";
+				}
+			}
+			return st.nextToken();
+		}
+	}
+	public static class Suf implements Comparable<Suf> {
+		int ind;
+		int[] rank;
+		Suf(int a, int b, int c) {
+			ind = a;
+			rank = new int[2];
+			rank[0] = b;
+			rank[1] = c;
+		}
+		public int compareTo(Suf s) {
+			return (rank[0] == s.rank[0]) ? (rank[1] - s.rank[1]) : (rank[0] - s.rank[0]);
+		}
+	}
+	/*
+	Event types:
+	0:  Beginning of contig
+	1:  Beginning of read mapping
+	2:  End of read mapping
+	3:  End of contig
+	 */
+	public static class Event implements Comparable<Event> {
+		int cont, loc, type;
+		Event(int a, int b, int c) {
+			cont = a;
+			loc = b;
+			type = c;
+		}
+		public int compareTo(Event e) {
+			if (cont == e.cont) {
+				if (loc == e.loc)
+					return type - e.type;
+				return loc - e.loc;
+			}
+			return cont - e.cont;
 		}
 	}
 }


### PR DESCRIPTION
This is currently untested right now - I need some FASTQ and corresponding FASTA files for contigs from some assemblers to test the read mapping, and unfortunately there isn't a resource with this stuff together, meaning I will need to run the assemblers myself to generate test data for the read mapping.  The original statistics still work fine, although I may fine-tune them a bit as we wrap this up.

I have provided the instructions for running this into the README again, as well as the updated list of statistics included, assuming the read-mapping works.  I will try to confirm that as soon as I can get the test data.  I also need to verify the specifics of the assembler output, as I have been assuming I am going to work with the contig FASTA file this entire time and may need to also work with the scaffold file - assemblers usually provide both as output, if SPAdes is anything to go off of.